### PR TITLE
fix(#11): address the dependency vulnerability by updating oath2orize to ^1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,104 @@
+{
+  "name": "oauth2orize-jwt-bearer",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oauth2orize-jwt-bearer",
+      "version": "0.2.0",
+      "dependencies": {
+        "oauth2orize": "^1.12.0",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "vows": "0.6.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+      "integrity": "sha512-1zEb73vemXFpUmfh3fsta4YHz3lwebxXvaWmPbFv9apujQBWDnkrPDLXLQs1gZo4RCWMDsT89r0Pf/z8/02TGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "dev": true,
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/oauth2orize": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/oauth2orize/-/oauth2orize-1.12.0.tgz",
+      "integrity": "sha512-j4XtFDQUBsvUHPjUmvmNDUDMYed2MphMIJBhyxVVe8hGCjkuYnjIsW+D9qk8c5ciXRdnk6x6tEbiO6PLeOZdCQ==",
+      "dependencies": {
+        "debug": "2.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+      "integrity": "sha512-7W7wTrE/NsY8xv/DTGjwNIyNah81EQH0MWcTzrHL6pOpMocOGZc0Mbdz9aXxSrp+U0mSmkU8jrNCDCfUs3sOBg==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vows": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.6.4.tgz",
+      "integrity": "sha512-CnnxhTuz08RHlAEagUSH6806IMxlOvYK5Nz5CyRGaqk9m2qVsP/0vtNBtU9rUS0TTrx3JYmPtHwIELaf+91t0Q==",
+      "dev": true,
+      "dependencies": {
+        "diff": "~1.0.3",
+        "eyes": ">=0.1.6"
+      },
+      "bin": {
+        "vows": "bin/vows"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,20 @@
   "name": "oauth2orize-jwt-bearer",
   "version": "0.2.0",
   "description": "JSON Web Token (JWT) Bearer Token Exchange Middleware for OAuth2orize.",
-  "keywords": ["oauth2orize", "oauth", "oauth2", "authn", "authentication", "authz", "authorization", "api", "jwt", "json", "token", "bearer"],
+  "keywords": [
+    "oauth2orize",
+    "oauth",
+    "oauth2",
+    "authn",
+    "authentication",
+    "authz",
+    "authorization",
+    "api",
+    "jwt",
+    "json",
+    "token",
+    "bearer"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/xtuple/oauth2orize-jwt-bearer.git"
@@ -15,14 +28,16 @@
     "email": "ben@xtuple.com",
     "url": "http://www.xtuple.com/"
   },
-  "licenses": [ {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT"
-  } ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
   "main": "./lib/oauth2orize-jwt-bearer",
   "dependencies": {
-    "pkginfo": "0.2.x",
-    "oauth2orize": "~0.1.0"
+    "oauth2orize": "^1.12.0",
+    "pkginfo": "0.2.x"
   },
   "devDependencies": {
     "vows": "0.6.x"
@@ -30,5 +45,7 @@
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
   },
-  "engines": { "node": ">= 0.4.0" }
+  "engines": {
+    "node": ">= 0.4.0"
+  }
 }


### PR DESCRIPTION
oath2orize imports the dependency debug, which has a vulnerability issue with any version below 2.6.9; updating oath2orize to version 1.12.0 would resolve the debug dependency version issue.